### PR TITLE
New PolyInterface class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 install: python setup.py install
 before_script:
 - 'mkdir ~/.polyglot && printf "Test=1\nUSE_HTTPS=false" > ~/.polyglot/.env'
-script: python tests.py
+script: python setup.py test
 notifications:
   slack:
     secure: RlFVwpMtWT0Txv2Xu2yC/Cm2jhdD3dKM9rbTcqnnc3Pi6JKBPEPOc9WQid4PGL0g+wTypPRMIlOYsC76Umddq+uc8SuoIMjBy2PIyuTHED4P7QN5pskYiVJvj0zst/oZ3XRrArCCFtKXsC+T8hsdFMPOjHoMM0JyKEah0X2PjMTppYwTcCr/NfUwxlV+fCXqOmUG373aVNLHwDE1LAL1BcT/6aLZ2NFcNJRkESXpxDoe7de2IquvVnwCbqft20VYtiLpb6mLzs/BlRZObfuq3OuLjAOFC9gl/I0DFGs3xibz19WVCYpwHKOU/oE0aovWV9T6/UHoxjQ4MdPUt+8F8+OXWrf8uuMblCTwRDbxIRtkB/Wi8WxzyXHgv+Gxz45OTX5JinGgOidI3xO3xlNCI119iLCQ8vm7B2nmuh7BJ2F62w9qeOuLYYh1M/2GOZ/Qz0xVb1w2NuqPJkiSOUlB1+KrNeoCpN6vIsc7Unvwh3OA3ZQtJv233jq9LCW24WGNbRf8eOqLpJfKDdvbV/mtNnLVxqmpIpvR9GwXFNC/o3m8TLE2EqD8z+18H6dBgtt4jSeFjWnNXOK+Y9ZULOnmugFotLIDvPP+WBb1yWF8azUBhku3HCUeBmaLiIuu7C2wpO4UBX42f/uw0mA+HUz6yLlPCC9U2gJ85xVE/M7NN5M=

--- a/polyinterface/__init__.py
+++ b/polyinterface/__init__.py
@@ -1,4 +1,4 @@
-from .polyinterface import Interface, Node, Controller, LOGGER, unload_interface
+from .polyinterface import PolyInterface, Interface, Node, Controller, LOGGER, unload_interface
 
 __version__ = '2.0.31'
 __description__ = 'UDI Polyglot v2 Interface'

--- a/polyinterface/polyinterface.py
+++ b/polyinterface/polyinterface.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 """
 Python Interface for UDI Polyglot v2 NodeServers
 by Einstein.42 (James Milne) milne.james@gmail.com

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(name='polyinterface',
     author=metadata['author'],
     author_email=metadata['authoremail'],
     license=metadata['license'],
-    packages=find_packages(),
+    packages=find_packages(where=".polyinterface"),
     install_requires=[
         "paho-mqtt",
         "python-dotenv",

--- a/tests.py
+++ b/tests.py
@@ -12,7 +12,7 @@ class TestPoly(TestCase):
 
 class TestPolyInstance(TestCase):
 
-    @mock.patch.dict(os.environ,{'PROFILE_NUM':'1234'})
+    @mock.patch.dict(os.environ,{'PROFILE_NUM':'1234', 'USE_HTTPS':'false'})
     def setUp(self):
         self.polyglot = Interface('Test')
 

--- a/tests.py
+++ b/tests.py
@@ -18,7 +18,3 @@ class TestPolyInstance(TestCase):
 
     def test_init(self):
         self.assertIsInstance(self.polyglot, Interface)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests.py
+++ b/tests.py
@@ -1,11 +1,23 @@
-import unittest
-import polyinterface
+from unittest import TestCase, mock
+from polyinterface import LOGGER, PolyInterface, Interface
+import os
 
-class TestPoly(unittest.TestCase):
+class TestPoly(TestCase):
+
 
     def test_poly(self):
-        polyglot = polyinterface.Interface('Test')
-        self.assertIsInstance(polyglot, polyinterface.Interface)
+        with self.assertRaises(SystemExit):
+            polyglot = Interface('Test')
+
+
+class TestPolyInstance(TestCase):
+
+    @mock.patch.dict(os.environ,{'PROFILE_NUM':'1234'})
+    def setUp(self):
+        self.polyglot = Interface('Test')
+
+    def test_init(self):
+        self.assertIsInstance(self.polyglot, Interface)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Change the behavior so the module wouldn't auto initialize. Allows for easier testability for Node Server projects.
Requires you to change the Node Server main functionality.
```
#!/usr/bin/env python
import sys
from poly_interface import LOGGER, PolyInterface, Interface
from nuvo_controller import Controller
if __name__ == "__main__":

    polyinterface = PolyInterface()
    polyglot = Interface('Example NodeServer')

    try:
        polyglot.start()
        control = Controller(polyglot)
        control.runForever()
    except (KeyboardInterrupt, SystemExit):
        polyglot.stop()
        sys.exit(0)
```