### PR TITLE
Reconfigure logger setup so others inherit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # __Changelog for Polyglot Python Interface v2__
 
+### Version 2.0.35
+- Use logger basicConifg so settings are shared by other modules used by NodeServers
+- Add module to logger, asked all devs for opinions but nobody responded.
+
 ### Version 2.0.34
 * Proper SSLError fix fix https://github.com/UniversalDevicesInc/polyglot-v2/issues/13
 

--- a/polyinterface/__init__.py
+++ b/polyinterface/__init__.py
@@ -1,6 +1,6 @@
 from .polyinterface import Interface, Node, Controller, LOGGER, unload_interface, get_network_interface
 
-__version__ = '2.0.32'
+__version__ = '2.0.33'
 __description__ = 'UDI Polyglot v2 Interface'
 __url__ = 'https://github.com/UniversalDevicesInc/polyglot-v2-python-interface'
 __author__ = 'James Milne'

--- a/polyinterface/__init__.py
+++ b/polyinterface/__init__.py
@@ -1,6 +1,6 @@
 from .polyinterface import Interface, Node, Controller, LOGGER, unload_interface, get_network_interface
 
-__version__ = '2.0.33'
+__version__ = '2.0.35'
 __description__ = 'UDI Polyglot v2 Interface'
 __url__ = 'https://github.com/UniversalDevicesInc/polyglot-v2-python-interface'
 __author__ = 'James Milne'

--- a/polyinterface/polyinterface.py
+++ b/polyinterface/polyinterface.py
@@ -250,8 +250,8 @@ class Interface(object):
         :param flags: The flags set on the connection.
         :param rc: Result code of connection, 0 = Success, anything else is a failure
         """
-        if current_thread().name != "MQTT":
-            current_thread().name = "MQTT"
+        if Thread.current_thread().name != "MQTT":
+            Thread.current_thread().name = "MQTT"
         if rc == 0:
             self.connected = True
             results = []

--- a/polyinterface/polyinterface.py
+++ b/polyinterface/polyinterface.py
@@ -59,6 +59,8 @@ def setup_log():
     if not os.path.exists('./logs'):
         os.makedirs('./logs')
     log_filename = "./logs/debug.log"
+    log_level = logging.DEBUG  # Could be e.g. "DEBUG" or "WARNING"
+
     # ### Logging Section ################################################################################
     logging.captureWarnings(True)
     # Set the log level to LOG_LEVEL
@@ -66,18 +68,19 @@ def setup_log():
     # making a new file at midnight and keeping 3 backups
     handler = logging.handlers.TimedRotatingFileHandler(log_filename, when="midnight", backupCount=30)
     # Format each log message like this
-    formatter = logging.Formatter('%(asctime)s [%(threadName)-10s] [%(levelname)-5s] %(message)s')
+    formatter = logging.Formatter('%(asctime)s [%(threadName)-10s] [%(module)-16s] [%(levelname)-5s] %(message)s')
     # Attach the formatter to the handler
     handler.setFormatter(formatter)
     # Attach the handler to the logger
     logging.basicConfig(
         handlers=[handler],
-        level=logging.DEBUG # Could be e.g. "DEBUG" or "WARNING"
+        level=logging.DEBUG
     )
     logger = logging.getLogger(__name__)
     logger.propagate = False # If True we get duplicates?
     warnlog = logging.getLogger('py.warnings')
     warnings.formatwarning = warning_on_one_line
+    logger.setLevel(log_level)
     logger.addHandler(handler)
     warnlog.addHandler(handler)
     return logger

--- a/polyinterface/polyinterface.py
+++ b/polyinterface/polyinterface.py
@@ -306,6 +306,11 @@ class Interface(object):
                 LOGGER.error('MQTT Received Unknown Message: {}: {}'.format(msg.topic, parsed_msg))
         except (ValueError) as err:
             LOGGER.error('MQTT Received Payload Error: {}'.format(err), exc_info=True)
+        except Exception as ex:
+            # Can any other exception happen?
+            template = "An exception of type {0} occured. Arguments:\n{1!r}"
+            message = template.format(type(ex).__name__, ex.args)
+            LOGGER.error("MQTT Received Unknown Error: " + message, exc_info=True)
 
     def _disconnect(self, mqttc, userdata, rc):
         """
@@ -329,17 +334,17 @@ class Interface(object):
 
     def _log(self, mqttc, userdata, level, string):
         """ Use for debugging MQTT Packets, disable for normal use, NOISY. """
-        # LOGGER.info('MQTT Log - {}: {}'.format(str(level), str(string)))
+        LOGGER.info('MQTT Log - {}: {}'.format(str(level), str(string)))
         pass
 
     def _subscribe(self, mqttc, userdata, mid, granted_qos):
         """ Callback for Subscribe message. Unused currently. """
-        # LOGGER.info("MQTT Subscribed Succesfully for Message ID: {} - QoS: {}".format(str(mid), str(granted_qos)))
+        LOGGER.info("MQTT Subscribed Succesfully for Message ID: {} - QoS: {}".format(str(mid), str(granted_qos)))
         pass
 
     def _publish(self, mqttc, userdata, mid):
         """ Callback for publish message. Unused currently. """
-        # LOGGER.info("MQTT Published message ID: {}".format(str(mid)))
+        LOGGER.info("MQTT Published message ID: {}".format(str(mid)))
         pass
 
     def start(self):
@@ -368,6 +373,7 @@ class Interface(object):
                 message = template.format(type(ex).__name__, ex.args)
                 LOGGER.error("MQTT Connection error: {}".format(message), exc_info=True)
                 done = True
+        LOGGER.debug("MQTT Done:")
 
     def stop(self):
         """

--- a/polyinterface/polyinterface.py
+++ b/polyinterface/polyinterface.py
@@ -290,7 +290,7 @@ class Interface(object):
                     return
                 del parsed_msg['node']
                 for key in parsed_msg:
-                    # LOGGER.debug('MQTT Received Message: {}: {}'.format(msg.topic, parsed_msg))
+                    LOGGER.debug('MQTT Received Message: {}: {}'.format(msg.topic, parsed_msg))
                     if key == 'config':
                         self.inConfig(parsed_msg[key])
                     elif key == 'connected':
@@ -302,7 +302,8 @@ class Interface(object):
                         self.input(parsed_msg)
                     else:
                         LOGGER.error('Invalid command received in message from Polyglot: {}'.format(key))
-
+            else:
+                LOGGER.error('MQTT Received Unknown Message: {}: {}'.format(msg.topic, parsed_msg))
         except (ValueError) as err:
             LOGGER.error('MQTT Received Payload Error: {}'.format(err), exc_info=True)
 

--- a/polyinterface/polyinterface.py
+++ b/polyinterface/polyinterface.py
@@ -22,7 +22,7 @@ except ImportError:
 import re
 import sys
 import select
-from threading import Thread
+from threading import Thread,current_thread
 import warnings
 import time
 import netifaces
@@ -250,8 +250,8 @@ class Interface(object):
         :param flags: The flags set on the connection.
         :param rc: Result code of connection, 0 = Success, anything else is a failure
         """
-        if Thread.current_thread().name != "MQTT":
-            Thread.current_thread().name = "MQTT"
+        if current_thread().name != "MQTT":
+            current_thread().name = "MQTT"
         if rc == 0:
             self.connected = True
             results = []

--- a/polyinterface/polyinterface.py
+++ b/polyinterface/polyinterface.py
@@ -250,6 +250,8 @@ class Interface(object):
         :param flags: The flags set on the connection.
         :param rc: Result code of connection, 0 = Success, anything else is a failure
         """
+        if current_thread().name != "MQTT":
+            current_thread().name = "MQTT"
         if rc == 0:
             self.connected = True
             results = []

--- a/polyinterface/polyinterface.py
+++ b/polyinterface/polyinterface.py
@@ -138,7 +138,7 @@ def init_interface():
             LOGGER.info('Received Config from STDIN.')
         except (Exception) as err:
             # e = sys.exc_info()[0]
-            LOGGER.error('Invalid formatted input. Skipping. %s', err, exc_info=True)
+            LOGGER.error('Invalid formatted input %s for line: %s', line, err, exc_info=True)
 
 
 def unload_interface():
@@ -166,6 +166,7 @@ class Interface(object):
         if self.__exists:
             warnings.warn('Only one Interface is allowed.')
             return
+        self.config = None
         self.connected = False
         self.profileNum = os.environ.get("PROFILE_NUM")
         if self.profileNum is None:
@@ -207,7 +208,6 @@ class Interface(object):
                     )
         # self._mqttc.tls_insecure_set(True)
         # self._mqttc.enable_logger(logger=LOGGER)
-        self.config = None
         # self.loop = asyncio.new_event_loop()
         self.loop = None
         self.inQueue = queue.Queue()
@@ -630,6 +630,7 @@ class Interface(object):
         against the profile_version stored in the db customData
         The profile will be installed if necessary.
         """
+        LOGGER.debug('check_profile:      config={}'.format(self.config))
         cdata = deepcopy(self.config['customData'])
         LOGGER.debug('check_profile:      customData={}'.format(cdata))
         LOGGER.debug('check_profile: profile_version={}'.format(serverdata['profile_version']))


### PR DESCRIPTION
When nodeservers use another module that can do logging if enabled with:
logging.getLogger('requests').setLevel(level)
it wouldn't work, but now with everyhting put in basicConfig on polyglot logger it works.

This also contained changes for when I was testing MQTT but they are disabled by default.